### PR TITLE
fix: Resolve final compilation errors in tome-cli

### DIFF
--- a/src-tauri/crates/tome-cli/src/main.rs
+++ b/src-tauri/crates/tome-cli/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
 
     let model_names: Vec<String> = all_models
         .iter()
-        .map(|(name, engine_name, _)| format!("{} ({})", name, engine_name))
+        .map(|(name, engine_name, _, _)| format!("{} ({})", name, engine_name))
         .collect();
 
     let selection = Select::with_theme(&ColorfulTheme::default())


### PR DESCRIPTION
This commit resolves the final set of compilation errors that were preventing the `tome-cli` crate from building successfully.

- In `db.rs`, the error handling within the `query_map` closure has been refactored. The `?` operator cannot be used directly inside a closure that doesn't return a `Result`. The logic has been changed to manually map the `anyhow::Error` to the `rusqlite::Error` expected by the closure, resolving the `E0277` errors.

- In `main.rs`, a `.map()` call was destructuring a 4-element tuple with a 3-element pattern. This has been corrected to `(_, _, _, _)` to match the data structure, resolving the `E0308` type mismatch error.