### PR TITLE
fix: Resolve final compilation error in tome-cli db.rs

### DIFF
--- a/src-tauri/crates/tome-cli/src/db.rs
+++ b/src-tauri/crates/tome-cli/src/db.rs
@@ -17,6 +17,19 @@ pub fn connect() -> Result<Connection> {
     Connection::open(&path).with_context(|| format!("Failed to open database at {}", path.display()))
 }
 
+// Define a custom error type to satisfy rusqlite's trait bounds.
+#[derive(Debug)]
+struct OptionsParseError(String);
+
+impl std::fmt::Display for OptionsParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for OptionsParseError {}
+
+
 /// Fetches all configured engines from the database.
 pub fn get_engines(conn: &Connection) -> Result<Vec<Engine>> {
     let mut stmt = conn.prepare("SELECT id, name, type, options FROM engines")?;
@@ -27,11 +40,10 @@ pub fn get_engines(conn: &Connection) -> Result<Vec<Engine>> {
             rusqlite::Error::FromSqlConversionFailure(
                 3,
                 rusqlite::types::Type::Text,
-                Box::new(anyhow::anyhow!(
+                Box::new(OptionsParseError(format!(
                     "Failed to parse options JSON for engine '{}': {}",
-                    engine_name,
-                    e
-                )),
+                    engine_name, e
+                ))),
             )
         })?;
 


### PR DESCRIPTION
This commit resolves the final `E0277` compilation error that was preventing the `tome-cli` crate from building.

The error was caused by attempting to convert an `anyhow::Error` into a `Box<dyn std::error::Error>` for the `rusqlite` library's error handling. The `anyhow::Error` type does not directly satisfy this trait bound in all contexts.

The fix involves creating a new, simple `OptionsParseError` struct that implements the standard `Display` and `Error` traits. This custom error type is then used within the `map_err` closure to wrap the JSON parsing error, satisfying the `rusqlite` library's type requirements and allowing the project to compile successfully.