### PR TITLE
fix: final build fixes and warning cleanup

### DIFF
--- a/src-tauri/crates/tome-cli/src/models.rs
+++ b/src-tauri/crates/tome-cli/src/models.rs
@@ -8,6 +8,7 @@ pub struct ClientOptions {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct Engine {
     pub id: i64,
     pub name: String,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -3,7 +3,7 @@ pub(crate) mod server;
 
 use std::collections::HashMap;
 
-use crate::state::{RunningSession, State};
+use crate::state::State;
 
 use anyhow::{anyhow, Result};
 use rmcp::model::CallToolRequestParam;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,7 +55,7 @@
         },
         "updater": {
             "active": false,
-            "pubkey": null,
+            "pubkey": "",
             "endpoints": [
                 "https://github.com/runebookai/tome/releases/latest/download/latest.json"
             ]


### PR DESCRIPTION
This commit provides the final set of fixes to ensure a clean, production-ready build.

- Sets the updater pubkey in `tauri.conf.json` to an empty string (`""`) instead of `null` to fix the `invalid type` bundler error.
- Adds `#[allow(dead_code)]` to the `Engine` struct in the CLI to suppress the compiler warning without breaking the database deserialization.
- Removes an unused import in `src/mcp.rs` to clean up the final build warnings.